### PR TITLE
[bug-fix] Changing tabs loses Tribute object in context

### DIFF
--- a/src/dashboard/Header/TabsMenu/TabsMenu.js
+++ b/src/dashboard/Header/TabsMenu/TabsMenu.js
@@ -8,7 +8,13 @@ export default function TabsMenu() {
   const [context, setContext] = useContext(Context);
 
   const handleTabChange = (event, tab) => {
-    setContext({ selectedTab: TABS.ordering[tab] });
+    setContext(state => {
+        Object.assign(
+            {}, 
+            state, 
+            {selectedTab: TABS.ordering[tab]}
+        )
+    });
   };
 
   const getTabs = () => {


### PR DESCRIPTION
issue #21 
When using context with how it's set up, treat it like Redux. You need dump previous state into a new object and have it set. Otherwise you lose everything that was stored there prior.